### PR TITLE
Rename version check function for readability

### DIFF
--- a/design_doc/lock.md
+++ b/design_doc/lock.md
@@ -29,3 +29,27 @@ The internal lock status is maintained as the following table. The first/second 
 | 63-2 | 1 | 0 |
 |:-:|:-:|:-:|
 | a shared lock counter | an SIX-lock flag | an X-lock flag|
+
+## `OptimisticLock`
+
+In our implementation, we use a *version-check* functionality for optimistic locking. You can get a version value via `GetVersion` and check its validity by `HasSameVersion`. The following code is a short example of version-based retries.
+
+```cpp
+while(true) {
+  // keep a current version value
+  const auto ver = opt_lock_.GetVersion();
+
+  // ...some codes for reading shared region...
+
+  if (opt_lock_.HasSameVersion(ver)) break;
+  // version check failed, so retry from getting a version value
+}
+```
+
+Our optimistic lock implementation has the same locks as `PessimisticLock`, and so you can use shared/exclusive/shared-intent-exclusive locks with version-based concurrency controls. Note that only `UnlockX` and `DowngradeToSIX` functions increment version values.
+
+The internal lock status is maintained as the following table. The lowest sixteen bits represent the number of threads that have acquired shared locks. The following two bits represent a shared lock with an intent-exclusive lock and an exclusive lock, respectively. If these bits are standing, it means any thread has acquired either X or SIX lock. The remaining bits maintain a current version value.
+
+| 63-18 | 17 | 16 | 15-0 |
+|:-:|:-:|:-:|:-:|
+| a version value | an X-lock flag | an SIX-lock flag | a shared lock counter |

--- a/include/lock/optimistic_lock.hpp
+++ b/include/lock/optimistic_lock.hpp
@@ -75,7 +75,7 @@ class OptimisticLock
    * @retval false otherwise.
    */
   auto
-  CheckVersion(const uint64_t expected) const  //
+  HasSameVersion(const uint64_t expected) const  //
       -> bool
   {
     const auto desired = lock_.load(std::memory_order_relaxed) & kSIXAndSBitsMask;

--- a/include/lock/optimistic_lock.hpp
+++ b/include/lock/optimistic_lock.hpp
@@ -74,7 +74,7 @@ class OptimisticLock
    * @retval true if the given version value is the same as a current one.
    * @retval false otherwise.
    */
-  auto
+  [[nodiscard]] auto
   HasSameVersion(const uint64_t expected) const  //
       -> bool
   {
@@ -240,25 +240,25 @@ class OptimisticLock
   static constexpr uint64_t kSLock = 0b001UL;
 
   /// a lock status for exclusive locks.
-  static constexpr uint64_t kXLock = 0b010UL << 16;
+  static constexpr uint64_t kXLock = 0b010UL << 16UL;
 
   /// a lock status for shared locks with intent-exclusive locks.
-  static constexpr uint64_t kSIXLock = 0b001UL << 16;
+  static constexpr uint64_t kSIXLock = 0b001UL << 16UL;
 
   /// a bit mask for removing an X-lock flag.
-  static constexpr uint64_t kSBitsMask = (~0UL) << 16;
+  static constexpr uint64_t kSBitsMask = (~0UL) << 16UL;
 
   /// a bit mask for removing an X-lock flag.
-  static constexpr uint64_t kXBitMask = ~(0b010UL << 16);
+  static constexpr uint64_t kXBitMask = ~(0b010UL << 16UL);
 
   /// a bit mask for removing SIX/X-lock flags.
-  static constexpr uint64_t kXAndSIXBitsMask = ~(0b011UL << 16);
+  static constexpr uint64_t kXAndSIXBitsMask = ~(0b011UL << 16UL);
 
   /// a bit mask for removing S/SIX-lock flags.
-  static constexpr uint64_t kSIXAndSBitsMask = (~0UL) << 17;
+  static constexpr uint64_t kSIXAndSBitsMask = (~0UL) << 17UL;
 
   /// a bit mask for removing S/SIX/X-lock flags.
-  static constexpr uint64_t kAllBitsMask = (~0UL) << 18;
+  static constexpr uint64_t kAllBitsMask = (~0UL) << 18UL;
 
   /// the maximum number of retries for preventing busy loops.
   static constexpr size_t kRetryNum = 10UL;

--- a/test/lock/optimistic_lock_test.cpp
+++ b/test/lock/optimistic_lock_test.cpp
@@ -70,11 +70,11 @@ class OptimisticLockFixture : public ::testing::Test
     TryLock(kSLock, expected_rc);
     ReleaseLock(lock_type);
 
-    ASSERT_EQ(lock_.CheckVersion(version), lock_type != kXLock);
+    ASSERT_EQ(lock_.HasSameVersion(version), lock_type != kXLock);
 
     t_.join();
 
-    ASSERT_EQ(lock_.CheckVersion(version), lock_type != kXLock);
+    ASSERT_EQ(lock_.HasSameVersion(version), lock_type != kXLock);
   }
 
   void
@@ -86,13 +86,13 @@ class OptimisticLockFixture : public ::testing::Test
     GetLock(lock_type);
     TryLock(kXLock, expected_rc);
     if (((lock_type == kSLock) || (lock_type == kSIXLock))) {
-      ASSERT_TRUE(lock_.CheckVersion(version));
+      ASSERT_TRUE(lock_.HasSameVersion(version));
     }
     ReleaseLock(lock_type);
 
     t_.join();
 
-    ASSERT_FALSE(lock_.CheckVersion(version));
+    ASSERT_FALSE(lock_.HasSameVersion(version));
   }
 
   void
@@ -106,11 +106,11 @@ class OptimisticLockFixture : public ::testing::Test
     TryLock(kSIXLock, expected_rc);
     ReleaseLock(lock_type);
 
-    ASSERT_EQ(lock_.CheckVersion(version), lock_type != kXLock);
+    ASSERT_EQ(lock_.HasSameVersion(version), lock_type != kXLock);
 
     t_.join();
 
-    ASSERT_EQ(lock_.CheckVersion(version), lock_type != kXLock);
+    ASSERT_EQ(lock_.HasSameVersion(version), lock_type != kXLock);
   }
 
   void
@@ -121,7 +121,7 @@ class OptimisticLockFixture : public ::testing::Test
     lock_.LockX();
     lock_.DowngradeToSIX();
 
-    ASSERT_FALSE(lock_.CheckVersion(version));
+    ASSERT_FALSE(lock_.HasSameVersion(version));
 
     switch (lock_type) {
       case kSLock:
@@ -157,12 +157,12 @@ class OptimisticLockFixture : public ::testing::Test
     ReleaseLock(lock_type);
 
     if (lock_type == kSLock) {
-      ASSERT_TRUE(lock_.CheckVersion(version));
+      ASSERT_TRUE(lock_.HasSameVersion(version));
     }
 
     t_.join();
 
-    ASSERT_FALSE(lock_.CheckVersion(version));
+    ASSERT_FALSE(lock_.HasSameVersion(version));
   }
 
   void
@@ -186,13 +186,13 @@ class OptimisticLockFixture : public ::testing::Test
       t.join();
     }
 
-    ASSERT_TRUE(lock_.CheckVersion(version));
+    ASSERT_TRUE(lock_.HasSameVersion(version));
 
     TryLock(kXLock, kExpectSucceed);
 
     t_.join();
 
-    ASSERT_FALSE(lock_.CheckVersion(version));
+    ASSERT_FALSE(lock_.HasSameVersion(version));
   }
 
   void
@@ -231,7 +231,7 @@ class OptimisticLockFixture : public ::testing::Test
     lock_.LockS();
     ASSERT_EQ(counter_, kThreadNum * kWriteNumPerThread);
     lock_.UnlockS();
-    ASSERT_FALSE(lock_.CheckVersion(version));
+    ASSERT_FALSE(lock_.HasSameVersion(version));
   }
 
   /*####################################################################################


### PR DESCRIPTION
@nrkt @zeromusu 
よく考えたら`CheckVersion`という関数名だと返り値が曖昧なので`HasSameVersion`に変えました．また，clang-tidyの警告を抑制するためのリファクタリングと，簡単なドキュメントの追加も行っています（いずれも動作は未変更）．

テストが通るのを確認したらマージしちゃうので，このライブラリを使用している方でも更新をお願いします．