### PR TITLE
Add fences to prevent reordering

### DIFF
--- a/include/lock/optimistic_lock.hpp
+++ b/include/lock/optimistic_lock.hpp
@@ -78,6 +78,7 @@ class OptimisticLock
   HasSameVersion(const uint64_t expected) const  //
       -> bool
   {
+    std::atomic_signal_fence(std::memory_order_release);
     const auto desired = lock_.load(std::memory_order_relaxed) & kSIXAndSBitsMask;
     return expected == desired;
   }
@@ -114,6 +115,7 @@ class OptimisticLock
   void
   UnlockS()
   {
+    std::atomic_signal_fence(std::memory_order_release);
     auto expected = lock_.load(std::memory_order_relaxed);
     auto desired = expected - kSLock;  // decrement read-counter
     while (!lock_.compare_exchange_weak(expected, desired, std::memory_order_relaxed)) {
@@ -225,6 +227,7 @@ class OptimisticLock
   void
   UnlockSIX()
   {
+    std::atomic_signal_fence(std::memory_order_release);
     lock_.fetch_sub(kSIXLock, std::memory_order_relaxed);
   }
 

--- a/test/lock/optimistic_lock_test.cpp
+++ b/test/lock/optimistic_lock_test.cpp
@@ -154,11 +154,10 @@ class OptimisticLockFixture : public ::testing::Test
     lock_.LockSIX();  // this lock is going to be released in TryUpgrade
     GetLock(lock_type);
     TryUpgrade(expected_rc);
-    ReleaseLock(lock_type);
-
     if (lock_type == kSLock) {
       ASSERT_TRUE(lock_.HasSameVersion(version));
     }
+    ReleaseLock(lock_type);
 
     t_.join();
 


### PR DESCRIPTION
@nrkt @zeromusu 

なんかめっちゃ厄介な（というより[コンパイルおよび実行時の命令並べ替え](https://www.kernel.org/doc/Documentation/memory-barriers.txt)に関する自分の理解の誤りに起因する）バグがあったので修正しました．大事なのは[こっちのコミット](https://github.com/dbgroup-nagoya-u/cpp-utility/commit/7e6687e077c70cf65046264103265725adbfa6eb)で`HasSameVersion`, `UnlockS`, `UnlockSIX`に対して[std::atomic_signal_fence](https://en.cppreference.com/w/cpp/atomic/atomic_signal_fence)を入れています[^1]．これによって，これら3関数を呼び出す前の読み書きがこの関数を実行する前に終了することが（たぶん）保証されます．

何言ってるの？と思うかもしれませんが，例えば元々の実装だと[このコード](https://github.com/dbgroup-nagoya-u/b-tree/blob/add-osl/include/b_tree/component/osl/node_varlen.hpp#L417)で変な値を子ノードポインタとして読んでセグフォになります．何が起きているかと言うと，（おそらくですが，）`std::memory_order_relaxed`で現在のバージョン値を読むとこの`load`命令に対する **同スレッド内での** 順序保証が一切ないため， **バージョン値を確認してからチャイルドポインタを読みにいく** という動作が起きうるのだと思われます．最初の`GetVersion`はacquireフェンスを持つので，この関数を呼んだ後に直前の排他ロック（with releaseフェンス）で書かれた値が読めることは保証されていたのですが，`GetVersion`以降の読み書き順序に関しては（[式自体や変数間の依存関係に関する順序](https://en.cppreference.com/w/cpp/atomic/memory_order)以外）何の保証もなかったのだと解釈しています．

で，今の実装では無理やりreleaseフェンスを入れて，上記の3関数を呼び出す前の読み書きがこのフェンスよりも後に来ないようにしています．つまり，共有ロックを取っている間ないしバージョンを取得してから確認するまでの間の読み書きが，これらの関数を呼び出す前に終わっていることを保証させ（られていると信じ）ています[^2]．一応OSLを64スレッドで結構な回数テストしましたが，元々の実装だとほぼ確実に失敗していたのに対し，こっちの実装に変えてからは上手く動いています．

とりあえず今もfightersで64スレッドでテストを回し続けているので，明日まで上手く動いていたらこのブランチもマージするつもりです．

[^1]: 本来の使用意図（割込発生時の命令順序の保持）とは違う気がしていますが，説明を読む限りコンパイル時の並べ替え抑制が処理の本質っぽいので使ってます．
[^2]: `std::atomic_thread_fence`でもいいんですが，共有ロックの解放やバージョン確認において他スレッドとのメモリ上での順序関係まで保証する必要はないはずなので，同スレッド内での順序保証として`std::atomic_signal_fence`を使っています．