### PR TITLE
Modify to return version after UnlockX and DowngradeToSIX

### DIFF
--- a/include/lock/optimistic_lock.hpp
+++ b/include/lock/optimistic_lock.hpp
@@ -218,8 +218,8 @@ class OptimisticLock
   DowngradeToSIX()  //
       -> uint64_t
   {
-    return (lock_.fetch_add(kXLock + kSIXLock, std::memory_order_release) + kXLock + kSIXLock)
-           & kAllBitsMask;
+    const auto old_ver = lock_.fetch_add(kXLock + kSIXLock, std::memory_order_release);
+    return (old_ver + kXLock + kSIXLock) & kAllBitsMask;
   }
 
   /**

--- a/include/lock/optimistic_lock.hpp
+++ b/include/lock/optimistic_lock.hpp
@@ -231,7 +231,8 @@ class OptimisticLock
   UnlockX()  //
       -> uint64_t
   {
-    return (lock_.fetch_add(kXLock, std::memory_order_release) + kXLock) & kAllBitsMask;
+    const auto old_ver = lock_.fetch_add(kXLock, std::memory_order_release);
+    return (old_ver + kXLock) & kAllBitsMask;
   }
 
   /**

--- a/include/lock/optimistic_lock.hpp
+++ b/include/lock/optimistic_lock.hpp
@@ -209,23 +209,29 @@ class OptimisticLock
   /**
    * @brief Downgrade an X lock to an SIX lock.
    *
+   * @retval version value after downgrade from an X lock to an SIX lock.
+   *
    * NOTE: if a thread that does not have an exclusive lock calls this function, it will
    * corrupt an internal lock status.
    */
-  void
-  DowngradeToSIX()
+  auto
+  DowngradeToSIX()  //
+      -> uint64_t
   {
-    lock_.fetch_add(kXLock + kSIXLock, std::memory_order_release);
+    return (lock_.fetch_add(kXLock + kSIXLock, std::memory_order_release) + kXLock + kSIXLock)
+           & kAllBitsMask;
   }
 
   /**
    * @brief Release an exclusive lock.
    *
+   * @retval version value after an exclusive lock release.
    */
-  void
-  UnlockX()
+  auto
+  UnlockX()  //
+      -> uint64_t
   {
-    lock_.fetch_add(kXLock, std::memory_order_release);
+    return (lock_.fetch_add(kXLock, std::memory_order_release) + kXLock) & kAllBitsMask;
   }
 
   /**


### PR DESCRIPTION
排他ロックの解放時にバージョン値を返すように修正
(`fetch_add`は変更前の値が返されるらしい([ref](https://cpprefjp.github.io/reference/atomic/atomic/fetch_add.html)))